### PR TITLE
Update service/tags_manager.php for postgres compatibility

### DIFF
--- a/service/tags_manager.php
+++ b/service/tags_manager.php
@@ -727,7 +727,7 @@ class tags_manager
 	public function calc_count_tags()
 	{
 		$sql = 'UPDATE ' . $this->table_prefix . TABLES::TAGS . ' t
-			SET t.count = (
+			SET count = (
 				SELECT COUNT(tt.id)
 				FROM ' . TOPICS_TABLE . ' topics,
 					' . FORUMS_TABLE . ' f,


### PR DESCRIPTION
When installing the extension on a board using postgres (tested on phpbb 3.1.2 w/ postgres 9.3) the update query using the table alias in the SET clause caused a query error.

In the scope where "t.count" is available, there is only one table in play, thus the table identifier "t" is unnecessary as the column "count" is not ambiguous.

Error message from phpBB on install attempt: http://pastebin.com/2Ac5sFhJ
