### PR TITLE
prosilver width property for tag cloud causes overflow

### DIFF
--- a/styles/prosilver/theme/rh_topictags.css
+++ b/styles/prosilver/theme/rh_topictags.css
@@ -102,6 +102,5 @@ and (max-width : 480px)
 	.rh_topictags_tagcloud li
 	{
 		display:	block;
-		width:		100%;
 	}
 }


### PR DESCRIPTION
Removed 100% width in .rh_topictags_tagcloud li

The 100% width causes the tagcloud to overflow to the right side when the canvas size is reduced to minimal width.
