### PR TITLE
Display bug: Tag changes in HTML template

### DIFF
--- a/styles/prosilver/template/show_tag.html
+++ b/styles/prosilver/template/show_tag.html
@@ -47,9 +47,11 @@
 		<!-- EVENT viewforum_body_topic_row_before -->
 		<li class="row<!-- IF topicrow.S_ROW_COUNT is even --> bg1<!-- ELSE --> bg2<!-- ENDIF --><!-- IF topicrow.S_POST_GLOBAL --> global-announce<!-- ENDIF --><!-- IF topicrow.S_POST_ANNOUNCE --> announce<!-- ENDIF --><!-- IF topicrow.S_POST_STICKY --> sticky<!-- ENDIF --><!-- IF topicrow.S_TOPIC_REPORTED --> reported<!-- ENDIF -->">
 			<!-- EVENT viewforum_body_topic_row_prepend -->
-			<dl class="row-item {topicrow.TOPIC_IMG_STYLE}">
-				<dt<!-- IF topicrow.TOPIC_ICON_IMG and S_TOPIC_ICONS --> style="background-image: url({T_ICONS_PATH}{topicrow.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> title="{topicrow.TOPIC_FOLDER_IMG_ALT}">
+			<dl title="{topicrow.TOPIC_FOLDER_IMG_ALT}">
+				<dt<!-- IF topicrow.TOPIC_ICON_IMG and S_TOPIC_ICONS --> style="background-image: url({T_ICONS_PATH}{topicrow.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> class="row-item {topicrow.TOPIC_IMG_STYLE}">
 					<!-- IF topicrow.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{topicrow.U_NEWEST_POST}" class="row-item-link"></a><!-- ENDIF -->
+				</dt>
+				<dd>
 					<div class="list-inner">
 						<!-- EVENT topiclist_row_prepend -->
 						<!-- IF topicrow.S_UNREAD_TOPIC and not S_IS_BOT -->
@@ -108,7 +110,7 @@
 
 						<!-- EVENT topiclist_row_append -->
 					</div>
-				</dt>
+				</dd>
 				<dd class="posts">{topicrow.REPLIES} <dfn>{L_REPLIES}</dfn></dd>
 				<dd class="views">{topicrow.VIEWS} <dfn>{L_VIEWS}</dfn></dd>
 				<dd class="lastpost">


### PR DESCRIPTION
I compared the HTML structure of your `show_tag` template and the standard phpBB topic view and found some minor differences. So I made the appropriate changes to the template, which fixed the display bug in the we_universal theme.

Compare https://www.phpbb.com/community/viewtopic.php?f=456&t=2263616&start=240#p14476431

I suppose that with some further tweaks the CSS workaround from https://github.com/RobertHeim/phpbb-ext-topictags/pull/84 shouldn't be needed anymore.
